### PR TITLE
Use rhcsh for ssh commands during testing

### DIFF
--- a/controller/test/cucumber/support/sql_helper.rb
+++ b/controller/test/cucumber/support/sql_helper.rb
@@ -22,7 +22,7 @@ module SQLHelper
       '-d' => '$OPENSHIFT_APP_NAME' # always use proper db name
     }
 
-    cmd = @psql_helper ? "psql" : "/usr/bin/psql"
+    cmd = "rhcsh #{@psql_helper ? "psql" : "/usr/bin/psql"}"
 
     # SCP the file so we don't have to worry about escaping SQL
     if @app.respond_to?(:scp_content)


### PR DESCRIPTION
Some postgres tests are having problems not executing `rhcsh` properly when running commands that have helpers/wrappers.

This is meant as a temporary stopgap until [this bug](https://bugzilla.redhat.com/show_bug.cgi?id=955849)  is resolved
